### PR TITLE
Fixing TypeError: 'NoneType' is not iterable

### DIFF
--- a/TKINETER APP ONCE
+++ b/TKINETER APP ONCE
@@ -22,7 +22,7 @@ if __name__ == '__main__':
         info = proc.info
         # print('info:{}'.format(info))
         
-        if info and PROCNAME in info['cmdline'] and PID != info['pid']:
+        if info['cmdline'] and PROCNAME in info['cmdline'] and PID != info['pid']:
             print('EXIT:{}'.format(proc.info))
             exit(0)
 


### PR DESCRIPTION
@wan-joe 
> info:{'name': 'Registry', 'pid': 96, 'cmdline': None}

Windows returns `'cmdline': None` instead of `'cmdline': []`